### PR TITLE
feat(mongo): allow user to specify mongo_server_version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,8 +19,8 @@ resource "azurerm_cosmosdb_account" "this" {
   kind                          = var.cosmos_api == "mongo" ? "MongoDB" : "GlobalDocumentDB"
   public_network_access_enabled = var.public_network_access_enabled
   ip_range_filter               = var.ip_firewall_enabled == true ? local.firewall_ips : null
-
-  key_vault_key_id                = var.key_vault_name != "" ? data.azurerm_key_vault_key.this[0].versionless_id : null
+  mongo_server_version          = var.mongo_server_version
+  key_vault_key_id              = var.key_vault_name != "" ? data.azurerm_key_vault_key.this[0].versionless_id : null
 
   tags = local.tags
 

--- a/mongo_variables.tf
+++ b/mongo_variables.tf
@@ -27,3 +27,8 @@ variable "mongo_db_collections" {
   description = "List of Cosmos DB Mongo collections to create. Some parameters are inherited from cosmos account."
   default     = {}
 }
+
+variable "mongo_server_version" {
+  type        = string
+  description = "The Server Version of the MongoDB account to be created."
+}


### PR DESCRIPTION
Allows the user to specificy the mongo_server_version used by the azurerm_cosmosdb_account resource rather than always defaulting to the default (which at time of writing is 3.2).